### PR TITLE
fixing checks in input updates to account for directional changes

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -402,6 +402,19 @@ mod tests {
             assert!(im.get_axis(Axes::Vert) <= 0.0);
             assert!(im.get_axis(Axes::Vert) >= -1.0);
         }
+
+        // Test the transition from 'up' to 'down'
+        im.update_axis_start(Axes::Vert, true);
+        while im.get_axis(Axes::Vert) < 1.0 {
+            im.update(0.16);
+        }
+        im.update_axis_start(Axes::Vert, false);
+        im.update(0.16);
+        assert!(im.get_axis(Axes::Vert) < 1.0);
+        im.update_axis_stop(Axes::Vert, true);
+        assert!(im.get_axis_raw(Axes::Vert) < 0.0);
+        im.update_axis_stop(Axes::Vert, false);
+        assert_eq!(im.get_axis_raw(Axes::Vert), 0.0);
     }
 
     #[test]

--- a/src/input.rs
+++ b/src/input.rs
@@ -163,14 +163,19 @@ impl<Axes, Buttons> InputState<Axes, Buttons>
             if axis_status.direction != 0.0 {
                 // Accelerate the axis towards the
                 // input'ed direction.
-                let abs_dx = f32::min(axis_status.acceleration * dt,
-                                      1.0 - f32::abs(axis_status.position));
-                let dx = if axis_status.direction > 0.0 {
-                    abs_dx
+                let vel = axis_status.acceleration * dt;
+                let pending_position = axis_status.position + if axis_status.direction > 0.0 {
+                    vel
                 } else {
-                    -abs_dx
+                    -vel
                 };
-                axis_status.position += dx;
+                axis_status.position = if pending_position > 1.0 {
+                    1.0
+                } else if pending_position < -1.0 {
+                    -1.0
+                } else {
+                    pending_position
+                }
             } else {
                 // Gravitate back towards 0.
                 let abs_dx = f32::min(axis_status.gravity * dt, f32::abs(axis_status.position));
@@ -216,7 +221,9 @@ impl<Axes, Buttons> InputState<Axes, Buttons>
                 if started {
                     let direction_float = if positive { 1.0 } else { -1.0 };
                     axis_status.direction = direction_float;
-                } else {
+                } else if (positive && axis_status.direction > 0.0)
+                    || (!positive && axis_status.direction < 0.0)
+                {
                     axis_status.direction = 0.0;
                 }
             }


### PR DESCRIPTION
This fixes issues when switching directions as detailed in #8.

As I was fixing it I also noticed that even if the axis has changed directions (ie you press left and then press right without releasing left) releasing the first key will halt all motion. This makes for a weird experience when shifting back and forth because sometimes you'll halt without intending to.

It might be worthwhile to run cargo fmt on this codebase at some point. I ran it while I was doing my pr and it made a huge change.

Really enjoy your library and your great work!