### PR TITLE
Input module ergonomics and features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ euclid = {version = "0.19", features = ["mint"]}
 
 [dev-dependencies]
 ezing = "0.2"
+rand = "0.7.3"

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -1,0 +1,158 @@
+//! Simple two-player input example.
+//! Control two squares, move them around and change their color.
+//!
+//! The left square is controlled by the controller: 
+//! * Use DPad on the controller to move around,
+//! * Press South button on the controller to change color,
+//!
+//! The right square is controller by the keyboard : 
+//! * Use Arrow Keys to move around,
+//! * Press Space on the controller to change color,
+//!
+//! Tested with a PS3 controller
+//!
+
+extern crate ggez;
+
+use ggez::graphics;
+use ggez::{Context, GameResult};
+use ggez::event::{KeyCode, KeyMods, Button};
+use ggez::input::gamepad::GamepadId;
+use ggez_goodies::Point2;
+use ggez_goodies::input::{InputState, InputBinding, InputStateBuilder};
+use graphics::{DrawParam, DrawMode, FillOptions, Mesh, Rect};
+
+#[derive(Hash, PartialEq, Eq, Clone, Debug)]
+enum GameAxis {
+    Horizontal,
+    Vertical,
+}
+
+#[derive(Hash, PartialEq, Eq, Clone, Debug)]
+enum GameButton {
+    ChangeColor,
+}
+
+struct MainState {
+    meshes: Vec<graphics::Mesh>,
+    colors: Vec<graphics::Color>,
+    pos: Vec<Point2>,
+    input_state: InputState<GameAxis, GameButton>,
+}
+
+impl MainState {
+    pub fn new(ctx: &mut Context, input_state: InputState<GameAxis, GameButton>) -> Self {
+        let meshes = (0..2).map(|_| {
+            Mesh::new_rectangle(
+                ctx,
+                DrawMode::Fill(FillOptions::default()),
+                Rect::new(0.,0.,32.,32.),
+                graphics::WHITE,
+            )
+            .expect("Failed to build mesh")
+        }).collect();
+
+        let pos = (0..2).map(|x| {
+            let x = (x + 1) * 64;
+            [x as f32, 32.].into()
+        }).collect(); 
+
+        MainState {
+            meshes,
+            pos,
+            colors: vec![graphics::WHITE, graphics::WHITE],
+            input_state,
+        }
+    }
+}
+
+impl ggez::event::EventHandler for MainState {
+    fn update(&mut self, ctx: &mut Context) -> GameResult<()> {
+        // Update all player positions
+        (0..2)
+        .for_each(|x: usize| {
+            let velocity_x = self.input_state.get_player_axis(GameAxis::Horizontal, x);
+            let velocity_y = self.input_state.get_player_axis(GameAxis::Vertical, x);
+            self.pos[x].x += velocity_x; 
+            self.pos[x].y += velocity_y; 
+            
+            if self.input_state.get_player_button_pressed(GameButton::ChangeColor, x) {
+                self.colors[x] = [rand::random::<f32>(), rand::random::<f32>(), rand::random::<f32>(), 1.].into();
+            }
+        });
+        
+        // Updates the input state
+        // Note: you must handle input *before* calling input.update() 
+        // because update clears the trigger detection flag 
+        // (for button_pressed and button_released)
+        let dt = ggez::timer::delta(ctx).as_secs_f32();
+        self.input_state.update(dt);
+        Ok(())
+    }
+    
+    fn draw(&mut self, ctx: &mut Context) -> GameResult<()> {
+        graphics::clear(ctx, graphics::BLACK); 
+
+        (0..2)
+        .map(|x: usize| {
+            graphics::draw(
+                ctx, 
+                &self.meshes[x], 
+                DrawParam::default().dest(self.pos[x].clone()).color(self.colors[x]),
+            )
+        })
+        .collect::<GameResult<()>>()?;
+        
+        graphics::present(ctx)
+    }
+
+    fn key_down_event(&mut self, _ctx: &mut Context, keycode: KeyCode, _keymods: KeyMods, repeat: bool) {
+        if repeat {
+            return;
+        }
+        self.input_state.update_key_down(keycode);
+    }
+
+    fn key_up_event(&mut self, _ctx: &mut Context, keycode: KeyCode, _keymods: KeyMods) {
+        self.input_state.update_key_up(keycode);
+    }
+
+    fn gamepad_button_down_event(&mut self, ctx: &mut Context, btn: Button, id: GamepadId) {
+        let id = ctx.gamepad_context.gamepad(id).id();
+        self.input_state.update_gamepad_down(btn, id.into())
+    }
+    
+    fn gamepad_button_up_event(&mut self, ctx: &mut Context, btn: Button, id: GamepadId) {
+        let id = ctx.gamepad_context.gamepad(id).id();
+        self.input_state.update_gamepad_up(btn, id.into())
+    }
+}
+
+fn main() -> ggez::GameResult<()> {
+    let (mut ctx, mut event_loop) = ggez::ContextBuilder::new("ggez-goodies input", "opinon")
+        .build()
+        .expect("Failed to build context");
+
+    // Player 0 is controlled using the gamepad
+    // Player 1 is controlled using arrow keys on the keyboard
+    let input_state = InputStateBuilder::new()
+    .with_binding(
+        InputBinding::new()
+            .bind_gamepad_button_to_axis(Button::DPadLeft, GameAxis::Horizontal, false)
+            .bind_gamepad_button_to_axis(Button::DPadRight, GameAxis::Horizontal, true)
+            .bind_gamepad_button_to_axis(Button::DPadUp, GameAxis::Vertical, false)
+            .bind_gamepad_button_to_axis(Button::DPadDown, GameAxis::Vertical, true)
+            .bind_gamepad_button_to_button(Button::South, GameButton::ChangeColor)
+        )
+        .with_binding(
+            InputBinding::new()
+                .bind_key_to_axis(KeyCode::Left, GameAxis::Horizontal, false)
+                .bind_key_to_axis(KeyCode::Right, GameAxis::Horizontal, true)
+                .bind_key_to_axis(KeyCode::Up, GameAxis::Vertical, false)
+                .bind_key_to_axis(KeyCode::Down, GameAxis::Vertical, true)
+                .bind_key_to_button(KeyCode::Space, GameButton::ChangeColor)
+        )
+        .build();
+    let mut state = MainState::new(&mut ctx, input_state);
+    ggez::event::run(&mut ctx, &mut event_loop, &mut state)
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -74,7 +74,7 @@ enum InputType {
 /// ```
 ///
 /// TODO: Desperately needs better name.
-#[derive(Debug, Copy, Clone, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Hash, Eq)]
 pub enum InputEffect<Axes, Buttons>
 where
     Axes: Eq + Hash + Clone,
@@ -90,7 +90,7 @@ where
 /// some simple linear smoothing of the axis value that
 /// is usually quite nice.  This also contains the state
 /// and constants necessary for that.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 struct AxisState {
     /// Where the axis currently is, in [-1, 1]
     position: f32,
@@ -118,7 +118,7 @@ impl Default for AxisState {
 }
 
 /// All the state necessary for a button press.
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq)]
 struct ButtonState {
     pressed: bool,
     pressed_last_frame: bool,
@@ -127,7 +127,7 @@ struct ButtonState {
 /// A struct that contains a mapping from physical input events
 /// (currently just `KeyCode`s) to whatever your logical Axis/Button
 /// types are.
-#[derive(Clone, PartialEq)]
+#[derive(Default, Debug, Eq, PartialEq, Clone)]
 pub struct InputBinding<Axes, Buttons>
 where
     Axes: Hash + Eq + Clone,
@@ -178,15 +178,15 @@ where
 
 /// The object that tracks the current state of the input controls,
 /// such as axes, bindings, etc.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct InputState<Axes, Buttons>
 where
     Axes: Hash + Eq + Clone,
     Buttons: Hash + Eq + Clone,
 {
-    // Input state for axes
+    /// Input state for axes
     axes: HashMap<Axes, AxisState>,
-    // Input states for buttons
+    /// Input states for buttons
     buttons: HashMap<Buttons, ButtonState>,
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -21,6 +21,9 @@
 //!
 //!
 //! TODO: Handle mouse, joysticks
+//! Joysticks will probably be a pain because gilrs (and hence ggez)
+//! returns their values as f32, which does not implement Hash or Eq, 
+//! making them unusable as keys for HashMaps.  
 
 use ggez::event::{Button, KeyCode};
 use std::collections::HashMap;

--- a/src/input.rs
+++ b/src/input.rs
@@ -478,7 +478,7 @@ where
 
     /// Signals to all player state that a key was released, updating them accordingly
     pub fn update_key_up(&mut self, key: KeyCode) {
-        self.update_key(key, true)
+        self.update_key(key, false)
     }
 
     /// Code reuse logic for update_key_down & update_key_up
@@ -833,12 +833,18 @@ mod tests {
         input_state.update_key_down(KeyCode::Down);
         assert!(input_state.get_player_axis_raw(Axes::Vert, 0) > 0.);
 
+        input_state.update_key_up(KeyCode::Down);
+        assert_eq!(input_state.get_player_axis_raw(Axes::Vert, 0), 0.);
+        
         input_state.update_gamepad_down(Button::DPadLeft, 1);
         assert!(input_state.get_player_axis_raw(Axes::Horz, 1) < 0.);
-
+        
         input_state.update_gamepad_up(Button::DPadLeft, 1);
         input_state.update_gamepad_down(Button::DPadRight, 1);
         assert!(input_state.get_player_axis_raw(Axes::Horz, 1) > 0.);
+        
+        input_state.update_gamepad_up(Button::DPadRight, 1);
+        assert_eq!(input_state.get_player_axis_raw(Axes::Horz, 1), 0.);
 
         input_state.update_gamepad_down(Button::East, 1);
         assert!(input_state.get_player_button_pressed(Buttons::A, 1));

--- a/src/input.rs
+++ b/src/input.rs
@@ -13,17 +13,18 @@
 //! fun.
 //! * Take ggez's event-based input API, and present event- or
 //! state-based API so you can do whichever you want.
-//! 
-//! In this module: 
-//! * "physical" means Hardware button 
-//! * "logical" means User-defined button 
+//!
+//! In this module:
+//! * "physical" means Hardware button
+//! * "logical" means User-defined button
 //! * "raw" means unaffected by tweening on input axes
-//! 
+//!
 //!
 //! TODO: Handle mouse, joysticks
 
 use ggez::event::{Button, KeyCode};
 use std::collections::HashMap;
+use std::fmt::Debug;
 use std::hash::Hash;
 
 // Okay, but how does it actually work?
@@ -244,7 +245,7 @@ where
     Buttons: Hash + Eq + Clone,
 {
     fn default() -> Self {
-        PlayerInputState::new() 
+        PlayerInputState::new()
     }
 }
 
@@ -310,13 +311,13 @@ where
         self.update_effect(InputEffect::Button(button), false);
     }
 
-    /// Used for testing purposes 
+    /// Used for testing purposes
     #[allow(dead_code)]
     pub fn update_axis_start(&mut self, axis: Axes, positive: bool) {
         self.update_effect(InputEffect::Axis(axis, positive), true);
     }
-    
-    /// Used for testing purposes 
+
+    /// Used for testing purposes
     #[allow(dead_code)]
     pub fn update_axis_stop(&mut self, axis: Axes, positive: bool) {
         self.update_effect(InputEffect::Axis(axis, positive), false);
@@ -395,22 +396,22 @@ where
     pub fn mouse_position() {
         unimplemented!()
     }
-    
+
     #[allow(dead_code)]
     pub fn mouse_scroll_delta() {
         unimplemented!()
     }
-    
+
     #[allow(dead_code)]
     pub fn get_mouse_button() {
         unimplemented!()
     }
-    
+
     #[allow(dead_code)]
     pub fn get_mouse_button_down() {
         unimplemented!()
     }
-    
+
     #[allow(dead_code)]
     pub fn get_mouse_button_up() {
         unimplemented!()
@@ -441,8 +442,8 @@ where
 
 impl<Axes, Buttons> Default for InputState<Axes, Buttons>
 where
-    Axes: Hash + Eq + Clone,
-    Buttons: Hash + Eq + Clone,
+    Axes: Hash + Eq + Clone + Debug,
+    Buttons: Hash + Eq + Clone + Debug,
 {
     fn default() -> Self {
         InputState::new()
@@ -454,8 +455,8 @@ const DEFAULT_PLAYER: usize = 0;
 
 impl<Axes, Buttons> InputState<Axes, Buttons>
 where
-    Axes: Hash + Eq + Clone,
-    Buttons: Hash + Eq + Clone,
+    Axes: Hash + Eq + Clone + Debug,
+    Buttons: Hash + Eq + Clone + Debug,
 {
     /// Default constructor for an empty InputState
     fn new() -> Self {
@@ -474,14 +475,14 @@ where
     pub fn update_key_down(&mut self, key: KeyCode) {
         self.update_key(key, true)
     }
-    
+
     /// Signals to all player state that a key was released, updating them accordingly
     pub fn update_key_up(&mut self, key: KeyCode) {
         self.update_key(key, true)
     }
-    
+
     /// Code reuse logic for update_key_down & update_key_up
-    /// Effectively signals the states that a key was pressed or released 
+    /// Effectively signals the states that a key was pressed or released
     fn update_key(&mut self, key: KeyCode, started: bool) {
         for (player_id, binding) in self.input_bindings.iter() {
             if let Some(effect) = binding.resolve(key) {
@@ -490,26 +491,26 @@ where
             }
         }
     }
-    
+
     /// Signals the target player's state that a physical Gamepad Button was pressed
     pub fn update_gamepad_down(&mut self, gp_button: Button, player_id: usize) {
         self.update_gamepad(gp_button, player_id, true)
     }
-    
+
     /// Signals the target player's state that a physical Gamepad Button was released
     pub fn update_gamepad_up(&mut self, gp_button: Button, player_id: usize) {
         self.update_gamepad(gp_button, player_id, false)
     }
-    
+
     /// Code reuse logic for update_gamepad_down & update_gamepad_up
-    /// Effectively signals the target player's state that a gamepad button 
-    /// was pressed or released 
+    /// Effectively signals the target player's state that a gamepad button
+    /// was pressed or released
     fn update_gamepad(&mut self, gp_button: Button, player_id: usize, started: bool) {
-        if let Some(effect) = 
-            self
-                .input_bindings
-                .get_mut(&player_id)
-                .and_then(|ib| ib.resolve_gamepad(gp_button)) {
+        if let Some(effect) = self
+            .input_bindings
+            .get_mut(&player_id)
+            .and_then(|ib| ib.resolve_gamepad(gp_button))
+        {
             let is = self.player_states.entry(player_id).or_default();
             is.update_effect(effect, started);
         }
@@ -517,21 +518,27 @@ where
 
     /// Gets the value of a logical axis for the target player
     pub fn get_player_axis(&self, axis: Axes, player_id: usize) -> f32 {
-        self.player_states.get(&player_id).map(|ps| ps.get_axis(axis)).unwrap_or(0.)
+        self.player_states
+            .get(&player_id)
+            .map(|ps| ps.get_axis(axis))
+            .unwrap_or(0.)
     }
-    
+
     /// Gets the value of a logical axis for the default player
     pub fn get_default_player_axis(&self, axis: Axes) -> f32 {
         self.get_player_axis(axis, DEFAULT_PLAYER)
     }
-    
+
     /// Gets the raw value of a logical axis for the target player.
     /// The raw value is the exact value of an axis at the present moment, not affected
     /// by the easing factor.
     pub fn get_player_axis_raw(&self, axis: Axes, player_id: usize) -> f32 {
-        self.player_states.get(&player_id).map(|ps| ps.get_axis_raw(axis)).unwrap_or(0.)
+        self.player_states
+            .get(&player_id)
+            .map(|ps| ps.get_axis_raw(axis))
+            .unwrap_or(0.)
     }
-    
+
     /// Gets the raw value of a logical axis for the default player.
     /// The raw value is the exact value of an axis at the present moment, not affected
     /// by the easing factor.
@@ -541,9 +548,12 @@ where
 
     /// Gets the state of a logical button for the target player
     pub fn get_player_button(&self, button: Buttons, player_id: usize) -> ButtonState {
-        self.player_states.get(&player_id).map(|ps| ps.get_button(button)).unwrap_or_default()
+        self.player_states
+            .get(&player_id)
+            .map(|ps| ps.get_button(button))
+            .unwrap_or_default()
     }
-    
+
     /// Gets the state of a logical button for the default player
     pub fn get_default_player_button(&self, button: Buttons) -> ButtonState {
         self.get_player_button(button, DEFAULT_PLAYER)
@@ -551,34 +561,43 @@ where
 
     /// Asks if the logical button is held down for the target player
     pub fn get_player_button_down(&self, button: Buttons, player_id: usize) -> bool {
-        self.player_states.get(&player_id).map(|ps| ps.get_button_down(button)).unwrap_or(false)
+        self.player_states
+            .get(&player_id)
+            .map(|ps| ps.get_button_down(button))
+            .unwrap_or(false)
     }
-    
+
     /// Asks if the logical button is held down for the default player
     pub fn get_default_player_button_down(&self, button: Buttons) -> bool {
         self.get_player_button_down(button, DEFAULT_PLAYER)
     }
-    
-    /// Asks if the logical button for the target player has just started 
-    /// being pressed during the last update 
+
+    /// Asks if the logical button for the target player has just started
+    /// being pressed during the last update
     pub fn get_player_button_pressed(&self, button: Buttons, player_id: usize) -> bool {
-        self.player_states.get(&player_id).map(|ps| ps.get_button_pressed(button)).unwrap_or(false)
+        self.player_states
+            .get(&player_id)
+            .map(|ps| ps.get_button_pressed(button))
+            .unwrap_or(false)
     }
-    
-    /// Asks if the logical button for the default player has just started 
-    /// being pressed during the last update 
+
+    /// Asks if the logical button for the default player has just started
+    /// being pressed during the last update
     pub fn get_default_player_button_pressed(&self, button: Buttons) -> bool {
         self.get_player_button_pressed(button, DEFAULT_PLAYER)
     }
 
-    /// Asks if the logical button for the target player has just 
-    /// been released during the last update 
+    /// Asks if the logical button for the target player has just
+    /// been released during the last update
     pub fn get_player_button_released(&self, button: Buttons, player_id: usize) -> bool {
-        self.player_states.get(&player_id).map(|ps| ps.get_button_released(button)).unwrap_or(false)
+        self.player_states
+            .get(&player_id)
+            .map(|ps| ps.get_button_released(button))
+            .unwrap_or(false)
     }
-    
+
     /// Asks if the logical button for the default player has just  
-    /// been released during the last update 
+    /// been released during the last update
     pub fn get_default_player_button_released(&self, button: Buttons) -> bool {
         self.get_player_button_pressed(button, DEFAULT_PLAYER)
     }
@@ -599,7 +618,105 @@ where
 
     /// Resets all players Input State
     pub fn reset_all_player_input_state(&mut self) {
-        self.player_states.values_mut().for_each(|ps| ps.reset_input_state())
+        self.player_states
+            .values_mut()
+            .for_each(|ps| ps.reset_input_state())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Builder pattern wrapping an InputState.
+///
+/// This can be used to create an InputState parametrized with bindings.
+/// For example, building an input state for a platformer game might look like this :
+///
+/// ```rust
+/// use ggez_goodies::input::{InputBinding, InputStateBuilder};
+/// use ggez::event::KeyCode;
+///
+/// #[derive(Debug, Hash, PartialEq, Eq, Clone)]
+/// enum MyAxes { Horizontal, Vertical }
+///
+/// #[derive(Debug, Hash, PartialEq, Eq, Clone)]
+/// enum MyButtons { Jump }
+///
+/// let input_state =
+///     InputStateBuilder::new()
+///     .with_binding(
+///         InputBinding::new()
+///             .bind_key_to_axis(KeyCode::Left, MyAxes::Horizontal, false) // Left is negative X    
+///             .bind_key_to_axis(KeyCode::Right, MyAxes::Horizontal, true) // Right is negative X
+///             .bind_key_to_axis(KeyCode::Up, MyAxes::Vertical, false)     // (in ggez's coordinate system) Up is negative Y
+///             .bind_key_to_axis(KeyCode::Down, MyAxes::Vertical, true)    // (in ggez's coordinate system) Down is positive Y
+///             .bind_key_to_button(KeyCode::Space, MyButtons::Jump)      // Space will make the player jump
+///     )
+///     .build();
+/// ```
+pub struct InputStateBuilder<Axes, Buttons>
+where
+    Axes: Hash + Eq + Clone,
+    Buttons: Hash + Eq + Clone,
+{
+    curr_player_id: usize,
+    bindings: HashMap<usize, InputBinding<Axes, Buttons>>,
+}
+
+impl<Axes, Buttons> Default for InputStateBuilder<Axes, Buttons>
+where
+    Axes: Hash + Eq + Clone,
+    Buttons: Hash + Eq + Clone,
+{
+    fn default() -> Self {
+        InputStateBuilder::new()
+    }
+}
+
+impl<Axes, Buttons> InputStateBuilder<Axes, Buttons>
+where
+    Axes: Hash + Eq + Clone,
+    Buttons: Hash + Eq + Clone,
+{
+    /// Default constructor for the InputStateBuilder.
+    /// Same as calling `default`.
+    pub fn new() -> Self {
+        InputStateBuilder {
+            curr_player_id: 0,
+            bindings: HashMap::default(),
+        }
+    }
+
+    /// Adds a binding to the input state being built
+    /// This binding will be used for the next unused player ID.
+    /// (on the first call, it will be 0)
+    pub fn with_binding(mut self, binding: InputBinding<Axes, Buttons>) -> Self {
+        // Because we allow inserting a binding for player X, we need to find
+        // an unused ID to make sure we do not accidentally override an
+        // existing InputBinding already set up by the user
+        let next_unused_id = (self.curr_player_id..)
+            .find(|id| self.bindings.get(id).is_none())
+            .unwrap();
+        self.curr_player_id = next_unused_id;
+        self.with_player_binding(binding, next_unused_id)
+    }
+
+    /// Adds a binding to the input state being built
+    /// This binding will be used for the specified player
+    pub fn with_player_binding(
+        mut self,
+        binding: InputBinding<Axes, Buttons>,
+        player_id: usize,
+    ) -> Self {
+        self.bindings.insert(player_id, binding);
+        self
+    }
+
+    /// Builds the InputState that has been parametrized
+    /// by this builder
+    pub fn build(self) -> InputState<Axes, Buttons> {
+        InputState {
+            player_states: HashMap::default(),
+            input_bindings: self.bindings,
+        }
     }
 }
 
@@ -633,6 +750,25 @@ mod tests {
             .bind_key_to_axis(KeyCode::Left, Axes::Horz, false)
             .bind_key_to_axis(KeyCode::Right, Axes::Horz, true);
         ib
+    }
+
+    fn make_input_binding_multiple() -> (InputBinding<Axes, Buttons>, InputBinding<Axes, Buttons>) {
+        (
+            InputBinding::<Axes, Buttons>::new()
+                .bind_key_to_axis(KeyCode::Up, Axes::Vert, false)
+                .bind_key_to_axis(KeyCode::Down, Axes::Vert, true)
+                .bind_key_to_axis(KeyCode::Left, Axes::Horz, false)
+                .bind_key_to_axis(KeyCode::Right, Axes::Horz, true)
+                .bind_key_to_button(KeyCode::Q, Buttons::A)
+                .bind_key_to_button(KeyCode::E, Buttons::B),
+            InputBinding::<Axes, Buttons>::new()
+                .bind_gamepad_button_to_axis(Button::DPadUp, Axes::Vert, false)
+                .bind_gamepad_button_to_axis(Button::DPadDown, Axes::Vert, true)
+                .bind_gamepad_button_to_axis(Button::DPadLeft, Axes::Horz, false)
+                .bind_gamepad_button_to_axis(Button::DPadRight, Axes::Horz, true)
+                .bind_gamepad_button_to_button(Button::East, Buttons::A)
+                .bind_gamepad_button_to_button(Button::South, Buttons::B),
+        )
     }
 
     #[test]
@@ -678,6 +814,42 @@ mod tests {
 
         assert_eq!(ib.resolve(KeyCode::Q), None);
         assert_eq!(ib.resolve(KeyCode::W), None);
+    }
+
+    #[test]
+    /// Tests that events are being correctly dispatched
+    /// Inner behaviour of PlayerInputState is verified by other tests
+    fn test_input_bindings_multiple() {
+        let (player_one, player_two) = make_input_binding_multiple();
+        let mut input_state = InputStateBuilder::new()
+            .with_binding(player_one)
+            .with_binding(player_two)
+            .build();
+
+        input_state.update_key_down(KeyCode::Up);
+        assert!(input_state.get_player_axis_raw(Axes::Vert, 0) < 0.);
+
+        input_state.update_key_up(KeyCode::Up);
+        input_state.update_key_down(KeyCode::Down);
+        assert!(input_state.get_player_axis_raw(Axes::Vert, 0) > 0.);
+
+        input_state.update_gamepad_down(Button::DPadLeft, 1);
+        assert!(input_state.get_player_axis_raw(Axes::Horz, 1) < 0.);
+
+        input_state.update_gamepad_up(Button::DPadLeft, 1);
+        input_state.update_gamepad_down(Button::DPadRight, 1);
+        assert!(input_state.get_player_axis_raw(Axes::Horz, 1) > 0.);
+
+        input_state.update_gamepad_down(Button::East, 1);
+        assert!(input_state.get_player_button_pressed(Buttons::A, 1));
+        assert!(input_state.get_player_button_down(Buttons::A, 1));
+        input_state.update(0.1);
+        assert!(!input_state.get_player_button_pressed(Buttons::A, 1));
+        assert!(input_state.get_player_button_down(Buttons::A, 1));
+
+        input_state.update_gamepad_up(Button::East, 1);
+        input_state.update_gamepad_down(Button::South, 1);
+        assert!(input_state.get_player_button_pressed(Buttons::B, 1));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #21 .

Refactors the Input module. 

* Follow Rust API Guidelines "Types eagerly implement common traits (C-COMMON-TRAITS)"
* Adds support for Gamepad (+ tests)
* Adds support for Multiplayer (+ tests)
* Adds an InputStateBuilder
*  Add Input example : 
    * Move squares around, 
    * Change their color by pressing a button
* Some cleanup (cargo fmt, comments)

# Breaking changes

* InputState has been renamed to PlayerInputState (and tests updated accordingly)
* InputState is now a struct that holds multiple PlayerInputState for multiplayer purposes. The public API remains globally the same, though.

# Notes 

* While InputState is still possible to build with `InputState::new()` and now also implements `Default` for `SPECS` usage, building an InputState from scratch should be discouraged, as it is preferable to use the new InputStateBuilder.
* I'm not really glad of the implementation of multiplayer support : I think code reuse could be done better, but the public API is clean and this PR does not break tests. 

# Caveats

* Mouse support still not implemented
* Joystick support still not implemented. This one might be a bit trickier because ggez exposes Axis values as f32, which are !Hash and !Eq, making them unusable for HashMap keys. If you have any insights feel free to let me know.
* Writing InputBinding as shown in the example is a bit verbose, it might also be possible to provide a `from_config` method to create it directly from a `.ron` file. Adding a dependency is a decision that should not be taken lightly though, and `RON` does not seem to be part of the ggez "ecosystem" yet, so that's a no-go for now. 